### PR TITLE
[codex] Add agent-owned study integration seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This package centers on reproducible agent workflows with a compact public API:
 - Two primary entry points: `DirectLLMCall` and `MultiStepAgent` (`direct`, `json`, and `code` modes)
 - A seeded random control-condition agent for packaged-problem studies (`SeededRandomBaselineAgent`)
 - A prompt-driven workflow agent for packaged-problem studies (`PromptWorkflowAgent`)
+- A study-facing integration seam in `design_research_agents.integration` for experiment runners
 - Workflow primitives for model, tool, delegate, loop, and memory steps
 - A tool runtime built around `Toolbox`, with callable, script, and MCP-backed tool configs
 - Hosted and local LLM clients, plus `ModelSelector` for backend-selection policies
@@ -98,6 +99,7 @@ The supported public surface is whatever is exported from
 Top-level exports include:
 
 - Agent entry points: `DirectLLMCall`, `MultiStepAgent`, `SeededRandomBaselineAgent`, `PromptWorkflowAgent`
+- Study-facing integration helpers: `integration` and `execute_agent_run`
 - Core contracts: `ExecutionResult`, `LLMRequest`, `LLMMessage`, `LLMResponse`, `ToolResult`
 - Workflow runtime: `Workflow`, `CompiledExecution`, and step contracts for model/tool/delegate/loop/memory behavior
 - Tools: `Toolbox`, `CallableToolConfig`, `ScriptToolConfig`, `MCPServerConfig`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ Highlights
 
 - Two core agent entry points: ``DirectLLMCall`` and ``MultiStepAgent``
 - Explicit multi-step modes for ``direct``, ``json``, and ``code`` execution
+- A study-facing integration seam in ``design_research_agents.integration``
 - Workflow primitives for model, tool, delegate, loop, and memory steps
 - Model-selection policies with local and remote catalogs
 - Tool contracts and schemas for safe, structured I/O
@@ -58,7 +59,9 @@ Typical Workflow
 2. Configure runtime mode, tools, models, and any workflow or memory helpers.
 3. Run a deterministic example or local quickstart to validate the environment.
 4. Inspect traces, tool boundaries, and structured outputs for debugging and evaluation.
-5. Reuse the same runtime contracts inside broader experiments and downstream analysis.
+5. Reuse the same runtime contracts inside broader experiments through
+   ``design_research_agents.integration.execute_agent_run(...)`` and in
+   downstream analysis.
 
 .. container:: drc-home-callout
 

--- a/src/design_research_agents/__init__.py
+++ b/src/design_research_agents/__init__.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Final
 
 from design_research_agents._lazy_exports import module_dir, resolve_lazy_export
-
-from . import integration
 
 _EXPORTS: Final[dict[str, str]] = {
     "DirectLLMCall": "design_research_agents.agent:DirectLLMCall",
@@ -82,6 +81,11 @@ def __getattr__(name: str) -> object:
     Raises:
         AttributeError: If ``name`` is not part of the public export map.
     """
+    if name == "integration":
+        module = import_module("design_research_agents.integration")
+        globals()[name] = module
+        return module
+
     return resolve_lazy_export(
         module_name=__name__,
         exports=_EXPORTS,

--- a/src/design_research_agents/__init__.py
+++ b/src/design_research_agents/__init__.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Final
 
 from design_research_agents._lazy_exports import module_dir, resolve_lazy_export
 
+from . import integration
+
 _EXPORTS: Final[dict[str, str]] = {
     "DirectLLMCall": "design_research_agents.agent:DirectLLMCall",
     "MultiStepAgent": "design_research_agents.agent:MultiStepAgent",
@@ -60,6 +62,7 @@ _EXPORTS: Final[dict[str, str]] = {
 }
 
 __all__ = ["__version__", *_EXPORTS.keys()]
+__all__.append("integration")
 
 try:
     __version__ = version("design-research-agents")
@@ -115,6 +118,7 @@ if TYPE_CHECKING:
     from .agent import MultiStepAgent as MultiStepAgent
     from .agent import PromptWorkflowAgent as PromptWorkflowAgent
     from .agent import SeededRandomBaselineAgent as SeededRandomBaselineAgent
+    from .integration import execute_agent_run as execute_agent_run
     from .llm import AnthropicServiceLLMClient as AnthropicServiceLLMClient
     from .llm import AzureOpenAIServiceLLMClient as AzureOpenAIServiceLLMClient
     from .llm import GeminiServiceLLMClient as GeminiServiceLLMClient

--- a/src/design_research_agents/integration.py
+++ b/src/design_research_agents/integration.py
@@ -7,7 +7,7 @@ import inspect
 import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import import_module
 from typing import Any
 
@@ -411,7 +411,7 @@ def _normalize_events(
 
 def _utc_now_iso() -> str:
     """Return the current UTC timestamp in ISO-8601 format."""
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def _hash_identifier(prefix: str, payload: Mapping[str, Any]) -> str:

--- a/src/design_research_agents/integration.py
+++ b/src/design_research_agents/integration.py
@@ -1,0 +1,424 @@
+"""Study-facing integration helpers for executable agents."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from importlib import import_module
+from typing import Any
+
+type AgentBinding = Any | Callable[[Any], Any]
+
+_AGENT_EXECUTION_PARAMETER_NAMES = frozenset(
+    {
+        "prompt",
+        "input",
+        "request_id",
+        "dependencies",
+    }
+)
+
+
+@dataclass(slots=True)
+class AgentExecutionEnvelope:
+    """Normalized execution envelope used by study-orchestration consumers."""
+
+    output: dict[str, Any] = field(default_factory=dict)
+    metrics: dict[str, Any] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    trace_refs: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def execute_agent_run(
+    agent_ref: Any,
+    *,
+    prompt: Any,
+    request_id: str | None,
+    dependencies: Mapping[str, object] | None,
+    agent_bindings: Mapping[str, AgentBinding] | None = None,
+) -> AgentExecutionEnvelope:
+    """Execute one public agent reference through the stable prompt/dependencies contract."""
+    resolved_dependencies = dict(dependencies or {})
+    condition = resolved_dependencies.get("condition")
+    executable = _resolve_agent_ref(
+        agent_ref,
+        condition=condition,
+        agent_bindings=agent_bindings,
+    )
+    raw = _invoke_agent(
+        executable=executable,
+        prompt=prompt,
+        request_id=request_id,
+        dependencies=resolved_dependencies,
+    )
+    return _normalize_agent_execution(raw=raw, request_id=request_id)
+
+
+def _resolve_agent_ref(
+    agent_ref: Any,
+    *,
+    condition: Any,
+    agent_bindings: Mapping[str, AgentBinding] | None,
+) -> Any:
+    """Resolve one agent reference into an executable object."""
+    if not isinstance(agent_ref, str):
+        return agent_ref
+
+    if agent_bindings and agent_ref in agent_bindings:
+        return _materialize_agent_binding(agent_bindings[agent_ref], condition)
+
+    exported = getattr(import_module("design_research_agents"), agent_ref, None)
+    if exported is None:
+        raise ValueError(
+            f"Unknown agent reference '{agent_ref}'. Register an agent binding or use a public export."
+        )
+
+    if inspect.isclass(exported):
+        return exported()
+    return exported
+
+
+def _materialize_agent_binding(binding: AgentBinding, condition: Any) -> Any:
+    """Resolve one binding into a concrete executable for the current condition."""
+    if _is_condition_scoped_binding(binding):
+        return binding(condition)
+    return binding
+
+
+def _is_condition_scoped_binding(binding: AgentBinding) -> bool:
+    """Return whether one binding is a condition-to-executable builder."""
+    if not callable(binding):
+        return False
+    if hasattr(binding, "run") and callable(binding.run):
+        return False
+
+    try:
+        parameters = inspect.signature(binding).parameters
+    except (TypeError, ValueError):
+        return False
+
+    if any(name in _AGENT_EXECUTION_PARAMETER_NAMES for name in parameters):
+        return False
+
+    if any(
+        parameter.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        for parameter in parameters.values()
+    ):
+        return False
+
+    positional_parameters = [
+        parameter
+        for parameter in parameters.values()
+        if parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    return len(parameters) == 1 and len(positional_parameters) == 1
+
+
+def _invoke_agent(
+    *,
+    executable: Any,
+    prompt: Any,
+    request_id: str | None,
+    dependencies: Mapping[str, object],
+) -> Any:
+    """Invoke one agent object or callable through the public prompt/dependencies contract."""
+    if hasattr(executable, "run") and callable(executable.run):
+        return _invoke_callable(
+            callable_obj=executable.run,
+            prompt=prompt,
+            request_id=request_id,
+            dependencies=dependencies,
+        )
+
+    if callable(executable):
+        return _invoke_callable(
+            callable_obj=executable,
+            prompt=prompt,
+            request_id=request_id,
+            dependencies=dependencies,
+        )
+
+    raise ValueError("Resolved agent object is not executable.")
+
+
+def _invoke_callable(
+    *,
+    callable_obj: Callable[..., Any],
+    prompt: Any,
+    request_id: str | None,
+    dependencies: Mapping[str, object],
+) -> Any:
+    """Invoke one callable using the stable agent-entrypoint contract."""
+    parameters = inspect.signature(callable_obj).parameters
+    kwargs: dict[str, Any] = {}
+
+    if "prompt" in parameters and parameters["prompt"].kind is not inspect.Parameter.POSITIONAL_ONLY:
+        kwargs["prompt"] = prompt
+    if "input" in parameters and parameters["input"].kind is not inspect.Parameter.POSITIONAL_ONLY:
+        kwargs["input"] = prompt
+    if "request_id" in parameters:
+        kwargs["request_id"] = request_id
+    if "dependencies" in parameters:
+        kwargs["dependencies"] = dependencies
+
+    if kwargs:
+        return callable_obj(**kwargs)
+
+    if not parameters:
+        return callable_obj()
+
+    positional_parameters = [
+        parameter
+        for parameter in parameters.values()
+        if parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    if len(positional_parameters) == 1:
+        return callable_obj(prompt)
+
+    raise ValueError(
+        "Agent execution target must accept the public prompt/request_id/dependencies "
+        "contract or a single prompt argument."
+    )
+
+
+def _normalize_agent_execution(
+    *,
+    raw: Any,
+    request_id: str | None,
+) -> AgentExecutionEnvelope:
+    """Normalize raw execution output to the canonical study-facing envelope."""
+    if _is_execution_result(raw):
+        return _normalize_execution_result(raw=raw, request_id=request_id)
+
+    if isinstance(raw, Mapping):
+        output = dict(raw.get("output", raw.get("outputs", {})))
+        if not output and "text" in raw:
+            output = {"text": raw["text"]}
+
+        metrics = dict(raw.get("metrics", {}))
+        trace_refs = [str(value) for value in raw.get("trace_refs", [])]
+        metadata = dict(raw.get("metadata", {}))
+        events = _normalize_events(
+            raw_events=raw.get("events", []),
+            request_id=request_id,
+            output=output,
+        )
+        return AgentExecutionEnvelope(
+            output=output,
+            metrics=metrics,
+            events=events,
+            trace_refs=trace_refs,
+            metadata=metadata,
+        )
+
+    output = {"text": str(raw)}
+    return AgentExecutionEnvelope(
+        output=output,
+        metrics={},
+        events=_normalize_events(raw_events=[], request_id=request_id, output=output),
+        trace_refs=[],
+        metadata={},
+    )
+
+
+def _is_execution_result(raw: Any) -> bool:
+    """Return whether one object looks like a design-research-agents `ExecutionResult`."""
+    if raw is None or isinstance(raw, Mapping):
+        return False
+    return all(hasattr(raw, attribute) for attribute in ("success", "output", "metadata"))
+
+
+def _normalize_execution_result(
+    *,
+    raw: Any,
+    request_id: str | None,
+) -> AgentExecutionEnvelope:
+    """Normalize a design-research-agents `ExecutionResult` into the study-facing envelope."""
+    output_mapping = _extract_output_mapping(getattr(raw, "output", {}))
+    output = _extract_execution_output(output_mapping)
+    raw_metadata = getattr(raw, "metadata", {})
+    metadata = dict(raw_metadata) if isinstance(raw_metadata, Mapping) else {}
+    model_response = getattr(raw, "model_response", None)
+    metadata.update(_extract_model_metadata(model_response))
+
+    metrics: dict[str, Any] = {}
+    raw_metrics = output_mapping.get("metrics")
+    if isinstance(raw_metrics, Mapping):
+        metrics.update(raw_metrics)
+    _merge_usage_metrics(metrics, model_response)
+
+    trace_refs = _extract_trace_refs(metadata)
+    raw_events = output_mapping.get("events", [])
+    normalized_raw_events = (
+        raw_events
+        if isinstance(raw_events, Sequence) and not isinstance(raw_events, (str, bytes))
+        else []
+    )
+    events = _normalize_events(
+        raw_events=normalized_raw_events,
+        request_id=request_id,
+        output=output,
+    )
+    return AgentExecutionEnvelope(
+        output=output,
+        metrics=metrics,
+        events=events,
+        trace_refs=trace_refs,
+        metadata=metadata,
+    )
+
+
+def _extract_output_mapping(raw_output: Any) -> dict[str, Any]:
+    """Normalize the raw execution output envelope to a plain mapping."""
+    if isinstance(raw_output, Mapping):
+        return dict(raw_output)
+    return {}
+
+
+def _extract_execution_output(output_mapping: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve the canonical output payload from a workflow-style envelope."""
+    final_output = output_mapping.get("final_output")
+    if isinstance(final_output, Mapping):
+        return dict(final_output)
+    if isinstance(final_output, str):
+        return {"text": final_output}
+    if final_output is not None:
+        return {"final_output": final_output}
+
+    if "text" in output_mapping:
+        return {"text": str(output_mapping["text"])}
+    if "model_text" in output_mapping:
+        return {"text": str(output_mapping["model_text"])}
+    return dict(output_mapping)
+
+
+def _merge_usage_metrics(metrics: dict[str, Any], model_response: Any) -> None:
+    """Merge token-usage metadata from an optional model response."""
+    usage = getattr(model_response, "usage", None)
+    if isinstance(usage, Mapping):
+        prompt_tokens = usage.get("prompt_tokens")
+        completion_tokens = usage.get("completion_tokens")
+        total_tokens = usage.get("total_tokens")
+    else:
+        prompt_tokens = getattr(usage, "prompt_tokens", None)
+        completion_tokens = getattr(usage, "completion_tokens", None)
+        total_tokens = getattr(usage, "total_tokens", None)
+
+    if isinstance(prompt_tokens, int):
+        metrics.setdefault("input_tokens", prompt_tokens)
+    if isinstance(completion_tokens, int):
+        metrics.setdefault("output_tokens", completion_tokens)
+    if isinstance(total_tokens, int):
+        metrics.setdefault("total_tokens", total_tokens)
+
+
+def _extract_model_metadata(model_response: Any) -> dict[str, Any]:
+    """Extract stable model metadata from an optional LLM response."""
+    metadata: dict[str, Any] = {}
+    model_name = getattr(model_response, "model", None)
+    if isinstance(model_name, str) and model_name.strip():
+        metadata["model_name"] = model_name
+    model_provider = getattr(model_response, "provider", None)
+    if isinstance(model_provider, str) and model_provider.strip():
+        metadata["model_provider"] = model_provider
+    return metadata
+
+
+def _extract_trace_refs(metadata: Mapping[str, Any]) -> list[str]:
+    """Extract canonical trace references from execution metadata."""
+    trace_refs: list[str] = []
+    trace_path = metadata.get("trace_path")
+    if isinstance(trace_path, str) and trace_path.strip():
+        trace_refs.append(trace_path)
+    raw_trace_refs = metadata.get("trace_refs")
+    if isinstance(raw_trace_refs, Sequence) and not isinstance(raw_trace_refs, (str, bytes)):
+        for value in raw_trace_refs:
+            if isinstance(value, str) and value.strip() and value not in trace_refs:
+                trace_refs.append(value)
+    return trace_refs
+
+
+def _normalize_events(
+    *,
+    raw_events: Sequence[Any],
+    request_id: str | None,
+    output: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Normalize raw event payloads into canonical event dictionaries."""
+    events: list[dict[str, Any]] = []
+
+    for index, raw_event in enumerate(raw_events):
+        if not isinstance(raw_event, Mapping):
+            continue
+        meta_json = raw_event.get("meta_json", {})
+        if not isinstance(meta_json, Mapping):
+            meta_json = {"value": meta_json}
+        event_payload: dict[str, Any] = {
+            "timestamp": str(raw_event.get("timestamp", _utc_now_iso())),
+            "record_id": str(
+                raw_event.get(
+                    "record_id",
+                    _hash_identifier(
+                        "evt",
+                        {
+                            "request_id": request_id,
+                            "index": index,
+                            "event_type": raw_event.get("event_type", "event"),
+                        },
+                    ),
+                )
+            ),
+            "text": str(raw_event.get("text", "")),
+            "session_id": str(raw_event.get("session_id", request_id or "")),
+            "actor_id": str(raw_event.get("actor_id", "agent")),
+            "event_type": str(raw_event.get("event_type", "event")),
+            "meta_json": dict(meta_json),
+        }
+        for key in ("level", "trial_id", "step_id", "tool_name", "evaluation_id", "run_id"):
+            if key in raw_event:
+                event_payload[key] = raw_event[key]
+        events.append(event_payload)
+
+    if events:
+        return events
+
+    return [
+        {
+            "timestamp": _utc_now_iso(),
+            "record_id": _hash_identifier("evt", {"request_id": request_id, "index": 0}),
+            "text": str(output.get("text", "")),
+            "session_id": str(request_id or ""),
+            "actor_id": "agent",
+            "event_type": "assistant_output",
+            "meta_json": {"auto_generated": True},
+            "level": "step",
+        }
+    ]
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC timestamp in ISO-8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _hash_identifier(prefix: str, payload: Mapping[str, Any]) -> str:
+    """Build one deterministic identifier for normalized event records."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    digest = hashlib.sha1(encoded).hexdigest()[:12]
+    return f"{prefix}-{digest}"
+
+
+__all__ = ["AgentExecutionEnvelope", "execute_agent_run"]

--- a/src/design_research_agents/integration.py
+++ b/src/design_research_agents/integration.py
@@ -74,9 +74,7 @@ def _resolve_agent_ref(
 
     exported = getattr(import_module("design_research_agents"), agent_ref, None)
     if exported is None:
-        raise ValueError(
-            f"Unknown agent reference '{agent_ref}'. Register an agent binding or use a public export."
-        )
+        raise ValueError(f"Unknown agent reference '{agent_ref}'. Register an agent binding or use a public export.")
 
     if inspect.isclass(exported):
         return exported()
@@ -263,9 +261,7 @@ def _normalize_execution_result(
     trace_refs = _extract_trace_refs(metadata)
     raw_events = output_mapping.get("events", [])
     normalized_raw_events = (
-        raw_events
-        if isinstance(raw_events, Sequence) and not isinstance(raw_events, (str, bytes))
-        else []
+        raw_events if isinstance(raw_events, Sequence) and not isinstance(raw_events, (str, bytes)) else []
     )
     events = _normalize_events(
         raw_events=normalized_raw_events,

--- a/tests/test_implementation_import_policy.py
+++ b/tests/test_implementation_import_policy.py
@@ -43,6 +43,7 @@ def test_internal_modules_and_packages_use_underscore_naming() -> None:
     }
     public_module_paths = {
         "__init__.py",
+        "integration.py",
         "workflow/workflow.py",
     }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,9 +65,7 @@ def test_seeded_random_and_prompt_workflow_normalize_to_same_envelope_shape() ->
     run_spec = _RunSpec(run_id="run-2", seed=11)
     condition = _Condition(condition_id="cond-b")
 
-    workflow = Workflow(
-        steps=(LogicStep(step_id="emit", handler=lambda _context: {"final_output": {"ok": True}}),)
-    )
+    workflow = Workflow(steps=(LogicStep(step_id="emit", handler=lambda _context: {"final_output": {"ok": True}}),))
 
     def _fake_run(
         input: str | dict[str, object] | None = None,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from design_research_agents import PromptWorkflowAgent, SeededRandomBaselineAgent, integration
+from design_research_agents._contracts._execution import ExecutionResult
+from design_research_agents.workflow import LogicStep, Workflow
+
+
+@dataclass(frozen=True)
+class _RunSpec:
+    run_id: str
+    seed: int
+
+
+@dataclass(frozen=True)
+class _Condition:
+    condition_id: str
+
+
+@dataclass(frozen=True)
+class _ProblemMetadata:
+    problem_id: str
+
+
+class _DecisionProblem:
+    def __init__(self) -> None:
+        self.metadata = _ProblemMetadata(problem_id="stub-decision")
+        self.prompt = "Choose one cooling-fin design."
+        self._candidates = (
+            {"fan_count": 4.0, "fin_gap_mm": 2.5},
+            {"fan_count": 6.0, "fin_gap_mm": 2.0},
+            {"fan_count": 8.0, "fin_gap_mm": 1.5},
+        )
+
+    def iter_candidates(self) -> tuple[dict[str, float], ...]:
+        return self._candidates
+
+
+def test_public_seeded_random_agent_executes_through_integration() -> None:
+    problem = _DecisionProblem()
+    run_spec = _RunSpec(run_id="run-1", seed=7)
+    condition = _Condition(condition_id="cond-a")
+
+    execution = integration.execute_agent_run(
+        "SeededRandomBaselineAgent",
+        prompt=problem,
+        request_id=run_spec.run_id,
+        dependencies={
+            "problem": problem,
+            "run_spec": run_spec,
+            "condition": condition,
+            "seed": run_spec.seed,
+        },
+    )
+
+    assert execution.output
+    assert execution.metadata["problem_id"] == "stub-decision"
+    assert execution.metadata["request_id"] == "run-1"
+    assert execution.events[0]["event_type"]
+
+
+def test_seeded_random_and_prompt_workflow_normalize_to_same_envelope_shape() -> None:
+    problem_packet = type("ProblemPacket", (), {"problem_id": "problem-1", "brief": "Pick one design."})()
+    run_spec = _RunSpec(run_id="run-2", seed=11)
+    condition = _Condition(condition_id="cond-b")
+
+    workflow = Workflow(
+        steps=(LogicStep(step_id="emit", handler=lambda _context: {"final_output": {"ok": True}}),)
+    )
+
+    def _fake_run(
+        input: str | dict[str, object] | None = None,
+        *,
+        execution_mode: str = "sequential",
+        failure_policy: str = "skip_dependents",
+        request_id: str | None = None,
+        dependencies: dict[str, object] | None = None,
+    ) -> ExecutionResult:
+        del execution_mode, failure_policy, dependencies
+        return ExecutionResult(
+            success=True,
+            output={
+                "final_output": {"prompt": input},
+                "metrics": {"primary_outcome": 1.0},
+                "events": [
+                    {
+                        "event_type": "assistant_output",
+                        "text": str(input),
+                        "actor_id": "agent",
+                    }
+                ],
+            },
+            metadata={"request_id": request_id or "", "trace_path": "traces/run-2.jsonl"},
+        )
+
+    workflow.run = _fake_run  # type: ignore[method-assign]
+    prompt_agent = PromptWorkflowAgent(
+        workflow=workflow,
+        prompt_builder=lambda packet, spec, current_condition: (
+            f"{packet.problem_id}:{spec.run_id}:{current_condition.condition_id}"
+        ),
+    )
+
+    prompt_execution = integration.execute_agent_run(
+        "prompt-agent",
+        prompt="ignored",
+        request_id=run_spec.run_id,
+        dependencies={
+            "problem_packet": problem_packet,
+            "run_spec": run_spec,
+            "condition": condition,
+            "seed": run_spec.seed,
+        },
+        agent_bindings={"prompt-agent": prompt_agent},
+    )
+    baseline_execution = integration.execute_agent_run(
+        SeededRandomBaselineAgent(seed=run_spec.seed),
+        prompt=_DecisionProblem(),
+        request_id="run-3",
+        dependencies={
+            "problem": _DecisionProblem(),
+            "run_spec": _RunSpec(run_id="run-3", seed=run_spec.seed),
+            "condition": condition,
+            "seed": run_spec.seed,
+        },
+    )
+
+    assert prompt_execution.output
+    assert prompt_execution.metrics
+    assert prompt_execution.events
+    assert isinstance(prompt_execution.trace_refs, list)
+    assert prompt_execution.metadata["request_id"] == "run-2"
+
+    assert baseline_execution.output
+    assert isinstance(baseline_execution.metrics, dict)
+    assert baseline_execution.events
+    assert isinstance(baseline_execution.trace_refs, list)
+    assert baseline_execution.metadata["request_id"] == "run-3"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -69,6 +69,7 @@ EXPECTED_PUBLIC_API = [
     "SGLangServerLLMClient",
     "ModelSelector",
     "Tracer",
+    "integration",
 ]
 
 EXPECTED_AGENT_API = [


### PR DESCRIPTION
## What changed
- add `design_research_agents.integration` with `AgentExecutionEnvelope` and `execute_agent_run(...)`
- move agent-run normalization for public exports, `ExecutionResult`, metrics, traces, and events into the package-owned seam
- export and document the study-facing contract and add contract coverage for seeded-random and prompt-workflow agents

## Why
Cross-library study execution should call an agent-owned execution boundary instead of letting experiments infer every packaged-agent shape itself.

## Impact
Experiment runners can execute packaged agent ids through one public seam while standalone agent usage stays unchanged.

## Validation
- `PYTHONPATH=src uv run --python 3.12 python -m pytest -q tests/test_integration.py tests/test_public_api.py`
