### PR TITLE
[codex] Add Python module MCP config helper

### DIFF
--- a/docs/tools/mcp.rst
+++ b/docs/tools/mcp.rst
@@ -45,6 +45,26 @@ Programmatic helpers
    )
    runtime.close()
 
+For Python module-backed servers, use ``MCPServerConfig.python_module(...)`` to
+avoid hand-building the ``python -m`` command.
+
+.. code-block:: python
+
+   from design_research_agents import MCPServerConfig, Toolbox
+
+   runtime = Toolbox(
+       enable_core_tools=False,
+       mcp_servers=(
+           MCPServerConfig.python_module(
+               id="drp_problem",
+               module="design_research_problems.mcp",
+               args=("pill_capsule_min_area", "--no-citation"),
+           ),
+       ),
+   )
+   tools = [spec.name for spec in runtime.list_tools()]
+   runtime.close()
+
 Troubleshooting
 ---------------
 

--- a/src/design_research_agents/tools/_config.py
+++ b/src/design_research_agents/tools/_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -74,6 +75,50 @@ class MCPServerConfig:
     """Explicit environment variables to set for the server process. This is a mapping of variable 
     names to their desired values. These variables will be included in the server's environment in 
     addition to any variables from the allowlist that are present in the parent process."""
+
+    @classmethod
+    def python_module(
+        cls,
+        *,
+        id: str,
+        module: str,
+        args: tuple[str | Path, ...] = (),
+        python: str | Path | None = None,
+        timeout_s: int = 20,
+        env_allowlist: tuple[str, ...] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> MCPServerConfig:
+        """Create a stdio server config for ``python -m <module>``.
+
+        Args:
+            id: Unique server identifier used in tool names and traces.
+            module: Importable Python module to launch with ``-m``.
+            args: Positional command-line arguments passed after the module.
+            python: Python executable to use. Defaults to the current interpreter.
+            timeout_s: Timeout in seconds for MCP server responses.
+            env_allowlist: Optional environment-variable allowlist override.
+            env: Explicit environment variables for the server process.
+
+        Returns:
+            MCP server config with a normalized module command.
+
+        Raises:
+            ValueError: If ``module`` is empty.
+        """
+        module_name = module.strip()
+        if not module_name:
+            raise ValueError("module must be a non-empty import path.")
+
+        command = (str(python or sys.executable), "-m", module_name, *(str(arg) for arg in args))
+        if env_allowlist is not None:
+            return cls(
+                id=id,
+                command=command,
+                timeout_s=timeout_s,
+                env_allowlist=tuple(env_allowlist),
+                env=dict(env or {}),
+            )
+        return cls(id=id, command=command, timeout_s=timeout_s, env=dict(env or {}))
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)

--- a/tests/test_tools_runtime_init_api.py
+++ b/tests/test_tools_runtime_init_api.py
@@ -35,6 +35,49 @@ def _rubric_script_tool() -> ScriptToolConfig:
     )
 
 
+def test_mcp_server_config_python_module_uses_current_interpreter_by_default() -> None:
+    config = MCPServerConfig.python_module(
+        id="drp_problem",
+        module="design_research_problems.mcp",
+        args=("pill_capsule_min_area", "--no-citation"),
+        env={"PYTHONPATH": "src"},
+    )
+
+    assert config.command == (
+        sys.executable,
+        "-m",
+        "design_research_problems.mcp",
+        "pill_capsule_min_area",
+        "--no-citation",
+    )
+    assert config.env == {"PYTHONPATH": "src"}
+    assert config.timeout_s == 20
+
+
+def test_mcp_server_config_python_module_normalizes_overrides() -> None:
+    config = MCPServerConfig.python_module(
+        id="local",
+        module=" example.server ",
+        args=(Path("server-data"),),
+        python=Path("/opt/python"),
+        timeout_s=5,
+        env_allowlist=("PATH",),
+    )
+
+    assert config.command == ("/opt/python", "-m", "example.server", "server-data")
+    assert config.timeout_s == 5
+    assert config.env_allowlist == ("PATH",)
+
+
+def test_mcp_server_config_python_module_rejects_empty_module() -> None:
+    try:
+        MCPServerConfig.python_module(id="empty", module=" ")
+    except ValueError as exc:
+        assert "module" in str(exc)
+    else:
+        raise AssertionError("empty module should fail")
+
+
 def test_default_constructor_lists_core_tools() -> None:
     runtime = Toolbox()
 


### PR DESCRIPTION
## What changed
- add `MCPServerConfig.python_module(...)` for stdio servers launched with `python -m <module>`
- cover command normalization, interpreter override, timeout/env passthrough, and empty-module validation
- document lower-ceremony Design Research Problems MCP server wiring for developer workflows

## Why
The forwarded PillOptimizer flow had to write a temporary MCP server script before the agent toolbox could connect to packaged problem tools. This gives developers a smaller, less error-prone configuration path across notebooks, scripts, and other local workflows.

## Validation
- `uv run --extra dev --python 3.12 python -m pytest -q tests/test_tools_runtime_init_api.py`
- `uv run --extra dev --python 3.12 python -m ruff check src/design_research_agents/tools/_config.py tests/test_tools_runtime_init_api.py`
- `uv run --extra dev --python 3.12 python -m ruff format --check src/design_research_agents/tools/_config.py tests/test_tools_runtime_init_api.py`
- `uv run --extra dev --python 3.12 python -m mypy src/design_research_agents/tools/_config.py`

Refs #102.
