### PR TITLE
[codex] Prepare Johnson Jumpstart release version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 <!-- release-callout:start -->
 > [!IMPORTANT]
-> Current monthly release: [Mayer Momentum - May 2026](https://github.com/cmudrc/design-research-agents/milestone/4)  
-> Due: June 1, 2026  
-> Tracks: May 2026 work
+> Current monthly release: [Johnson Jumpstart - June 2026](https://github.com/cmudrc/design-research-agents/milestone/5)  
+> Due: July 1, 2026  
+> Tracks: June 2026 work
 <!-- release-callout:end -->
 
 `design-research-agents` is the agent-execution layer in the cmudrc design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # Core package metadata used by pip/PyPI tooling.
 [project]
 name = "design-research-agents"
-version = "0.4.0"
+version = "0.4.1"
 description = "A flexible, modular framework for researching engineering design AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/design_research_agents/tools/_sources/_mcp_source.py
+++ b/src/design_research_agents/tools/_sources/_mcp_source.py
@@ -64,7 +64,7 @@ class _SdkStdioMcpClient:
                             read_timeout_seconds=timedelta(seconds=self._server.timeout_s),
                             client_info=types_module.Implementation(
                                 name="design-research-agents",
-                                version="0.4.0",
+                                version="0.4.1",
                             ),
                         ) as session:
                             await session.initialize()
@@ -104,7 +104,7 @@ class _SdkStdioMcpClient:
                             read_timeout_seconds=timedelta(seconds=self._server.timeout_s),
                             client_info=types_module.Implementation(
                                 name="design-research-agents",
-                                version="0.4.0",
+                                version="0.4.1",
                             ),
                         ) as session:
                             await session.initialize()


### PR DESCRIPTION
## Summary
- bump package metadata from 0.4.0 to 0.4.1
- update MCP client self-identification to 0.4.1
- update the README release callout for Johnson Jumpstart - June 2026

## June milestone scope
- #42 Add OpenWebUI integration for interacting with agents, patterns, and workflows
- #21 Slack integration skeleton (command -> router -> response) + logging linkback
- #18 Audio input + transcription interface (scaffold + file-based MVP)
- #17 Image output (text -> image) tool interface + artifact attachments

## Validation
- uv run --extra dev make qa