### PR TITLE
[codex] Add DERP MCP general solver example

### DIFF
--- a/docs/dependencies_and_extras.rst
+++ b/docs/dependencies_and_extras.rst
@@ -97,6 +97,8 @@ Recommended install profiles:
 
 - hosted OpenAI-family studies: ``pip install -e ".[dev,openai]"``
 - hosted provider comparisons: ``pip install -e ".[dev,providers]"``
+- DRAG/DERP MCP workflows:
+  ``pip install "design-research-agents[mcp,gemini]" "design-research-problems[mcp]"``
 - Hugging Face catalog discovery: ``pip install -e ".[dev,huggingface]"``
 - Chroma-backed memory experiments: ``pip install -e ".[dev,memory_chroma]"``
 - graph-memory experiments: ``pip install -e ".[dev,memory_graph]"``

--- a/docs/examples/tools/derp_mcp_general_solver.rst
+++ b/docs/examples/tools/derp_mcp_general_solver.rst
@@ -35,7 +35,7 @@ Technical Implementation
 
 .. literalinclude:: ../../../examples/tools/derp_mcp_general_solver.py
    :language: python
-   :lines: 52-
+   :lines: 53-
    :linenos:
 
 Expected Results
@@ -66,3 +66,4 @@ References
 
 - `design-research-problems documentation <https://cmudrc.github.io/design-research-problems/>`_
 - `Model Context Protocol Specification <https://modelcontextprotocol.io/specification/2025-06-18>`_
+- `SciPy optimize documentation <https://docs.scipy.org/doc/scipy/reference/optimize.html>`_

--- a/docs/examples/tools/derp_mcp_general_solver.rst
+++ b/docs/examples/tools/derp_mcp_general_solver.rst
@@ -1,0 +1,68 @@
+Derp MCP General Solver
+=======================
+
+Source: ``examples/tools/derp_mcp_general_solver.py``
+
+Introduction
+------------
+
+This example shows the maintained DRAG + DERP path for selecting a packaged
+design-research problem, exposing it as an MCP tool server, and reading solver
+hints before making any optimization call. It is intentionally small: use the
+DERP catalog API for problem discovery, use the packaged DERP MCP CLI for tool
+launch, and keep provider-specific LLM setup outside the problem plumbing.
+
+Technical Implementation
+------------------------
+
+1. Search DERP with ``search_problem_summaries(...)`` instead of putting full
+   problem briefs into the agent prompt.
+2. Load the selected optimization problem and read ``solver_hints()`` directly
+   so variable domain and constraints do not need to be inferred from prose.
+3. Attach the packaged DERP MCP CLI with ``MCPServerConfig.python_module(...)``.
+4. Invoke ``solver_hints`` and ``evaluate`` through ``Toolbox`` and print one
+   compact JSON payload.
+
+.. mermaid::
+
+   flowchart LR
+       A["DERP search_problem_summaries"] --> B["Select problem id"]
+       B --> C["DERP solver_hints()"]
+       B --> D["python -m design_research_problems.mcp"]
+       D --> E["DRAG Toolbox MCP tools"]
+       C --> F["Agent-ready routing payload"]
+       E --> F
+
+.. literalinclude:: ../../../examples/tools/derp_mcp_general_solver.py
+   :language: python
+   :lines: 52-
+   :linenos:
+
+Expected Results
+----------------
+
+.. rubric:: Run Command
+
+.. code-block:: bash
+
+   PYTHONPATH=src python3 examples/tools/derp_mcp_general_solver.py
+
+When ``design-research-problems[mcp]`` is available, the example prints a JSON
+object containing the selected problem summary, local solver hints, MCP tool
+names, MCP solver hints, and one evaluation report. If DERP is not installed,
+it exits successfully with an ``available: false`` payload and an install hint.
+
+.. code-block:: text
+
+   {
+     "available": true,
+     "example": "tools/derp_mcp_general_solver.py",
+     "mcp_tools": ["drp_problem::evaluate", "drp_problem::solver_hints", "drp_problem::submit_final"],
+     "problem_id": "pill_capsule_min_area"
+   }
+
+References
+----------
+
+- `design-research-problems documentation <https://cmudrc.github.io/design-research-problems/>`_
+- `Model Context Protocol Specification <https://modelcontextprotocol.io/specification/2025-06-18>`_

--- a/docs/examples/tools/index.rst
+++ b/docs/examples/tools/index.rst
@@ -6,6 +6,7 @@ Generated from canonical example docstrings/comments in ``examples/tools``.
 .. toctree::
    :maxdepth: 1
 
+   derp_mcp_general_solver
    mcp_minimal
    multi_source_tool_usage
    script_tools_repo_quickscan

--- a/docs/tools/mcp.rst
+++ b/docs/tools/mcp.rst
@@ -65,12 +65,45 @@ avoid hand-building the ``python -m`` command.
    tools = [spec.name for spec in runtime.list_tools()]
    runtime.close()
 
+For packaged ``design-research-problems`` tasks, launch DERP's maintained MCP
+entrypoint directly. This avoids temporary server scripts and keeps problem
+briefs, evaluation tools, and solver hints on the library-owned path.
+
+.. code-block:: bash
+
+   python -m pip install "design-research-agents[mcp,gemini]" "design-research-problems[mcp]"
+
+.. code-block:: python
+
+   from design_research_agents import MCPServerConfig, Toolbox
+
+   runtime = Toolbox(
+       enable_core_tools=False,
+       mcp_servers=(
+           MCPServerConfig.python_module(
+               id="drp_problem",
+               module="design_research_problems.mcp",
+               args=("pill_capsule_min_area", "--no-citation"),
+               timeout_s=45,
+           ),
+       ),
+   )
+   hints = runtime.invoke(
+       "drp_problem::solver_hints",
+       {},
+       request_id="docs-derp-hints",
+       dependencies={},
+   )
+   runtime.close()
+
 Troubleshooting
 ---------------
 
 - ``Server '<id>' is not configured``: validate ``mcp.enabled`` and server id.
 - ``Unknown MCP tool '<name>'``: inspect ``Toolbox.list_tools()`` for available names.
-- Timeouts: increase ``timeout_s``.
+- Timeouts: the error includes ``timeout_s`` and the stdio command. Increase
+  ``MCPServerConfig.timeout_s`` for genuinely long-running tools; otherwise
+  verify the command and captured stderr.
 - Missing env vars: set both ``env_allowlist`` and ``env`` entries.
 
 Examples
@@ -78,4 +111,5 @@ Examples
 
 - ``examples/tools/mcp_minimal.py``
 - ``examples/tools/multi_source_tool_usage.py``
+- ``examples/tools/derp_mcp_general_solver.py``
 - ``examples/tools/README.md``

--- a/examples/tools/README.md
+++ b/examples/tools/README.md
@@ -9,6 +9,8 @@ sources for design-analysis workflows.
   - Traced MCP-only runtime and namespaced invocation.
 - `multi_source_tool_usage.py`
   - Traced multi-source run combining core/script/MCP tools.
+- `derp_mcp_general_solver.py`
+  - Maintained DRAG + DERP problem-selection and MCP evaluation path.
 - `script_tools/README.md`
   - Script-tool examples and direct execution commands.
 
@@ -17,6 +19,7 @@ sources for design-analysis workflows.
 ```bash
 PYTHONPATH=src python3 examples/tools/mcp_minimal.py
 PYTHONPATH=src python3 examples/tools/multi_source_tool_usage.py
+PYTHONPATH=src python3 examples/tools/derp_mcp_general_solver.py
 bash examples/tools/script_tools/repo_quickscan.sh <<'JSON'
 {"include_hidden":false}
 JSON

--- a/examples/tools/derp_mcp_general_solver.py
+++ b/examples/tools/derp_mcp_general_solver.py
@@ -1,0 +1,165 @@
+"""# Tools / DERP MCP General Solver.
+
+## Introduction
+This example shows the maintained DRAG + DERP path for selecting a packaged
+design-research problem, exposing it as an MCP tool server, and reading solver
+hints before making any optimization call. It is intentionally small: use the
+DERP catalog API for problem discovery, use the packaged DERP MCP CLI for tool
+launch, and keep provider-specific LLM setup outside the problem plumbing.
+
+
+## Technical Implementation
+1. Search DERP with ``search_problem_summaries(...)`` instead of putting full
+   problem briefs into the agent prompt.
+2. Load the selected optimization problem and read ``solver_hints()`` directly
+   so variable domain and constraints do not need to be inferred from prose.
+3. Attach the packaged DERP MCP CLI with ``MCPServerConfig.python_module(...)``.
+4. Invoke ``solver_hints`` and ``evaluate`` through ``Toolbox`` and print one
+   compact JSON payload.
+
+```mermaid
+flowchart LR
+    A["DERP search_problem_summaries"] --> B["Select problem id"]
+    B --> C["DERP solver_hints()"]
+    B --> D["python -m design_research_problems.mcp"]
+    D --> E["DRAG Toolbox MCP tools"]
+    C --> F["Agent-ready routing payload"]
+    E --> F
+```
+
+
+## Expected Results
+When ``design-research-problems[mcp]`` is available, the example prints a JSON
+object containing the selected problem summary, local solver hints, MCP tool
+names, MCP solver hints, and one evaluation report. If DERP is not installed,
+it exits successfully with an ``available: false`` payload and an install hint.
+
+.. code-block:: text
+
+   {
+     "available": true,
+     "example": "tools/derp_mcp_general_solver.py",
+     "mcp_tools": ["drp_problem::evaluate", "drp_problem::solver_hints", "drp_problem::submit_final"],
+     "problem_id": "pill_capsule_min_area"
+   }
+
+
+## References
+- `design-research-problems documentation <https://cmudrc.github.io/design-research-problems/>`_
+- `Model Context Protocol Specification <https://modelcontextprotocol.io/specification/2025-06-18>`_
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import design_research_agents as drag
+
+INSTALL_HINT = 'python -m pip install "design-research-agents[mcp,gemini]" "design-research-problems[mcp]"'
+
+
+def _missing_derp_payload(reason: str) -> dict[str, object]:
+    return {
+        "available": False,
+        "example": "tools/derp_mcp_general_solver.py",
+        "reason": reason,
+        "install_hint": INSTALL_HINT,
+    }
+
+
+def _load_derp() -> Any | None:
+    try:
+        import design_research_problems as derp
+    except ImportError:
+        return None
+    required = ("search_problem_summaries", "get_problem", "OptimizationProblem")
+    if not all(hasattr(derp, name) for name in required):
+        return None
+    return derp
+
+
+def _run_derp_workflow() -> dict[str, object]:
+    derp = _load_derp()
+    if derp is None:
+        return _missing_derp_payload("design-research-problems with catalog summaries is not importable.")
+
+    summaries = derp.search_problem_summaries(text="pill", kind="optimization")
+    if not summaries:
+        return _missing_derp_payload("No optimization problem summary matched the query.")
+
+    summary = next(
+        (candidate for candidate in summaries if candidate.problem_id == "pill_capsule_min_area"),
+        summaries[0],
+    )
+    problem = derp.get_problem(summary.problem_id)
+    if not isinstance(problem, derp.OptimizationProblem):
+        return _missing_derp_payload(f"Selected problem is not optimization-backed: {summary.problem_id}")
+
+    local_solver_hints = problem.solver_hints()
+    initial_candidate = problem.generate_initial_solution(seed=3).tolist()
+
+    try:
+        with drag.Toolbox(
+            enable_core_tools=False,
+            mcp_servers=(
+                drag.MCPServerConfig.python_module(
+                    id="drp_problem",
+                    module="design_research_problems.mcp",
+                    args=(summary.problem_id, "--no-citation"),
+                    timeout_s=45,
+                ),
+            ),
+        ) as runtime:
+            mcp_tools = sorted(spec.name for spec in runtime.list_tools() if spec.name.startswith("drp_problem::"))
+            mcp_hints = runtime.invoke(
+                "drp_problem::solver_hints",
+                {},
+                request_id="example-derp-solver-hints",
+                dependencies={},
+            )
+            evaluation = runtime.invoke(
+                "drp_problem::evaluate",
+                {"x": initial_candidate},
+                request_id="example-derp-evaluate",
+                dependencies={},
+            )
+    except Exception as exc:
+        return {
+            "available": True,
+            "example": "tools/derp_mcp_general_solver.py",
+            "problem_id": summary.problem_id,
+            "problem_summary": summary.to_dict(),
+            "local_solver_hints": local_solver_hints,
+            "mcp_available": False,
+            "mcp_error": str(exc),
+            "install_hint": INSTALL_HINT,
+        }
+
+    return {
+        "available": True,
+        "example": "tools/derp_mcp_general_solver.py",
+        "problem_id": summary.problem_id,
+        "problem_summary": summary.to_dict(),
+        "local_solver_hints": local_solver_hints,
+        "mcp_tools": mcp_tools,
+        "mcp_solver_hints": {
+            "ok": mcp_hints.ok,
+            "result": mcp_hints.result,
+            "error": mcp_hints.error,
+        },
+        "mcp_evaluation": {
+            "ok": evaluation.ok,
+            "result": evaluation.result,
+            "error": evaluation.error,
+        },
+    }
+
+
+def main() -> None:
+    """Run the maintained DERP MCP workflow and print JSON."""
+    print(json.dumps(_run_derp_workflow(), ensure_ascii=True, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tools/derp_mcp_general_solver.py
+++ b/examples/tools/derp_mcp_general_solver.py
@@ -47,6 +47,7 @@ it exits successfully with an ``available: false`` payload and an install hint.
 ## References
 - `design-research-problems documentation <https://cmudrc.github.io/design-research-problems/>`_
 - `Model Context Protocol Specification <https://modelcontextprotocol.io/specification/2025-06-18>`_
+- `SciPy optimize documentation <https://docs.scipy.org/doc/scipy/reference/optimize.html>`_
 """
 
 from __future__ import annotations

--- a/src/design_research_agents/tools/_sources/_mcp_source.py
+++ b/src/design_research_agents/tools/_sources/_mcp_source.py
@@ -183,7 +183,13 @@ class _SdkStdioMcpClient:
         except Exception as exc:
             stderr = self._stderr_preview()
             suffix = f" stderr={stderr!r}" if stderr else ""
-            raise McpProtocolError(f"MCP server '{self._server.id}' request failed: {exc}{suffix}") from exc
+            command_text = " ".join(self._server.command) if self._server.command else "<empty>"
+            raise McpProtocolError(
+                f"MCP server '{self._server.id}' request failed "
+                f"(timeout_s={self._server.timeout_s}, command={command_text!r}): {exc}{suffix}. "
+                "If the server is doing useful long-running work, raise MCPServerConfig.timeout_s; "
+                "otherwise verify the stdio command and captured stderr."
+            ) from exc
 
     def close(self) -> None:
         """Close the client facade.

--- a/tests/test_mcp_source_contracts.py
+++ b/tests/test_mcp_source_contracts.py
@@ -199,3 +199,30 @@ def test_sdk_client_stderr_preview_is_bounded() -> None:
     assert len(preview) <= 2001
     client.close()
     assert client._stderr_preview() == ""
+
+
+def test_sdk_client_failure_message_includes_timeout_and_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = ToolPolicy(ToolPolicyConfig(workspace_root="."))
+    client = mcp_source._SdkStdioMcpClient(
+        server=MCPServerConfig(id="alpha", command=("python3", "-c", "pass"), timeout_s=7),
+        policy=policy,
+    )
+
+    class _RaisingAnyio:
+        def run(self, async_fn: object) -> object:
+            del async_fn
+            raise TimeoutError("operation timed out")
+
+    monkeypatch.setattr(
+        mcp_source,
+        "_import_mcp_sdk_modules",
+        lambda: (_RaisingAnyio(), object(), object(), object()),
+    )
+
+    with pytest.raises(McpProtocolError) as exc_info:
+        client._run(lambda: None)
+
+    message = str(exc_info.value)
+    assert "timeout_s=7" in message
+    assert "command='python3 -c pass'" in message
+    assert "raise MCPServerConfig.timeout_s" in message


### PR DESCRIPTION
## Summary

- Improve MCP request failure messages with `timeout_s` and the stdio command for easier diagnosis.
- Document the maintained `python -m design_research_problems.mcp ...` launch path for packaged DERP problems.
- Add `examples/tools/derp_mcp_general_solver.py` plus generated docs for problem selection, solver hints, and MCP evaluation.

## Validation

- `/Users/work/Codex/repos/session-rescue/design-research-agents/.venv/bin/python -m ruff check src/design_research_agents/tools/_sources/_mcp_source.py tests/test_mcp_source_contracts.py examples/tools/derp_mcp_general_solver.py`
- `/Users/work/Codex/repos/session-rescue/design-research-agents/.venv/bin/python -m ruff format --check src/design_research_agents/tools/_sources/_mcp_source.py tests/test_mcp_source_contracts.py examples/tools/derp_mcp_general_solver.py`
- `PYTHONPATH=src /Users/work/Codex/repos/session-rescue/design-research-agents/.venv/bin/python -m pytest -q tests/test_mcp_source_contracts.py`
- `/Users/work/Codex/repos/session-rescue/design-research-agents/.venv/bin/python -m mypy src`
- `/Users/work/Codex/repos/session-rescue/design-research-agents/.venv/bin/python scripts/generate_example_docs.py --check`
- `/Users/work/Codex/repos/session-rescue/design-research-agents/.venv/bin/python scripts/check_docs_consistency.py`
- `PYTHONPATH=/Users/work/Codex/repos/session-rescue/design-research-agents-derp-mcp-general-solver/src:/Users/work/Codex/repos/session-rescue/design-research-problems-derp-catalog-solver-hints/src /Users/work/Codex/repos/session-rescue/design-research-problems-derp-catalog-solver-hints/.venv/bin/python examples/tools/derp_mcp_general_solver.py`