### PR TITLE
[codex] Document VS Code example path for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,33 +56,18 @@ Use the smallest useful check while iterating, then run full gates before merge.
 - Do not reintroduce removed legacy/fallback paths; CI enforces this.
 - Do not silence complexity issues with `# noqa: C901`; split code instead.
 
-## Release Naming
-- Theme: famous folks in STEM, with a bias toward women and historically underrepresented figures when possible.
-- Monthly work-cycle names are shared across milestone titles, release PR titles, and release branches.
-- Name the cycle for the month the work is done, not the later drop month.
-  - Milestone title / PR title: `{base name} - {Work month YYYY}`
-  - Release branch: slugified full title, for example `lovelace-lift-april-2026`
-- Milestone due dates should land in the first week of the following month.
-- Milestone descriptions must use:
-  - `Work month: {Month YYYY}.`
-  - `Theme source: <url>`
-- Release PR bodies must repeat the same `Theme source:` link used on the milestone and refer to the same work month named in the title.
-- Never reuse an exact base name or the same primary subject across any work month or any of the four design-research module repos unless all four `AGENTS.md` files are intentionally updated together.
-- Before adding a new release name, check the `Release Naming` tables in all four repos to avoid repeats.
-- `The April Alignment` is a carry-forward exception for the April 1, 2026 milestone and remains unchanged.
-
-| Work month | Target drop | Base name | Source subject |
-| --- | --- | --- | --- |
-| March 2026 | April 1, 2026 | The April Alignment | Carry-forward exception (existing April 2026 milestone) |
-| April 2026 | May 1, 2026 | Lovelace Lift | Ada Lovelace |
-| May 2026 | June 1, 2026 | Mayer Momentum | Maria Goeppert Mayer |
-| June 2026 | July 1, 2026 | Johnson Jumpstart | Katherine Johnson |
-| July 2026 | August 1, 2026 | Jemison Journey | Mae Jemison |
-| August 2026 | September 1, 2026 | Noether Nexus | Emmy Noether |
-| September 2026 | October 1, 2026 | Ochoa Orbit | Ellen Ochoa |
-| October 2026 | November 1, 2026 | Ride Relay | Sally Ride |
-| November 2026 | December 1, 2026 | Doudna Drive | Jennifer Doudna |
-| December 2026 | January 1, 2027 | Jackson Junction | Shirley Ann Jackson |
+## Release Planning
+- Do not create monthly milestone naming tables, themed release PR names, or
+  calendar release branches as default maintenance.
+- Prefer small issue/PR-scoped planning and package version releases driven by
+  user-facing changes.
+- Use GitHub milestones only for explicit, short-lived initiatives with an
+  active owner; they are optional scheduling aids, not release gates.
+- Name release branches and release PRs for the version or concrete change set
+  they contain.
+- When publishing, update package metadata, docs, examples, and GitHub
+  Releases/PyPI notes as needed. Do not add README callouts that point to
+  monthly milestones.
 
 ## Keep This File Up To Date
 Update this file when contributor-facing workflow changes. In particular:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@
 [![PyPI Version](https://img.shields.io/pypi/v/design-research-agents.svg)](https://pypi.org/project/design-research-agents/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/design-research-agents.svg)](https://pypi.org/project/design-research-agents/)
 
-<!-- release-callout:start -->
-> [!IMPORTANT]
-> Current monthly release: [Mayer Momentum - May 2026](https://github.com/cmudrc/design-research-agents/milestone/4)  
-> Due: June 1, 2026  
-> Tracks: May 2026 work
-<!-- release-callout:end -->
-
 `design-research-agents` is the agent-execution layer in the cmudrc design
 research ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ and package-install steps.
 If you prefer a guided editor-first flow, use the
 [VS Code Setup Guide](https://cmudrc.github.io/design-research-agents/vscode_setup.html).
 It walks through creating a virtual environment, installing the published
-package, and running a first script in VS Code.
+package, running a first script in VS Code, and using the source checkout for
+repository examples.
 
 ```bash
 python3 -m venv .venv

--- a/docs/vscode_setup.rst
+++ b/docs/vscode_setup.rst
@@ -1,113 +1,58 @@
-VS Code Setup Guide
-===================
+Run An Example In VS Code
+=========================
 
-This guide covers the library-specific steps for using the published
-``design-research-agents`` package in VS Code.
+Use this page when you want to try ``design-research-agents`` in VS Code.
+Choose the installed-package path for a first user workflow, or the source
+checkout path when you want to run the repository's checked-in examples and
+development checks.
 
-Requires Python 3.12+.
+The checked-in ``examples/`` directory lives in the repository source. Do not
+assume those files are present inside the PyPI wheel.
 
-1. Install The Prerequisites
-----------------------------
+Requirements
+------------
 
-Install VS Code, and make sure you have access to a Python 3.12 or newer
-interpreter.
-
-- `Visual Studio Code <https://code.visualstudio.com/download>`_
-- `Python 3.12 or newer <https://www.python.org/downloads/>`_ if you do not
-  already have a compatible interpreter
+- Python 3.12 or newer.
+- VS Code with the Python extension.
+- A VS Code integrated terminal.
 
 For the editor setup itself, follow the official `Getting Started with Python in
 VS Code <https://code.visualstudio.com/docs/python/python-tutorial/>`_
 tutorial. It covers installing the Python and Pylance extensions, opening a
 folder, selecting an interpreter, and running a Python file in VS Code.
 
-After that, come back here for the package-specific steps below.
+Installed Package From PyPI
+---------------------------
 
-Windows note:
-When installing Python, enable the option that adds ``python`` to your
-``PATH`` so the integrated terminal can find it.
-
-2. Create Or Open A Workspace Folder
-------------------------------------
-
-In VS Code, choose ``File > Open Folder...`` and open a folder for your own
-project, such as ``design-research-study``.
-
-If VS Code asks whether you trust the authors of the files in that folder,
-choose the option that trusts the workspace so Python features and terminals
-can run normally.
-
-You do not need to clone this repository to use the library.
-
-3. Create A Virtual Environment
--------------------------------
-
-Open ``Terminal > New Terminal`` and create a virtual environment in your
-workspace folder.
+Open an empty folder in VS Code, then create and activate a virtual
+environment from ``Terminal > New Terminal``.
 
 On macOS or Linux:
 
 .. code-block:: bash
 
-   python3 -m venv .venv
+   python -m venv .venv
    source .venv/bin/activate
-
-On Windows:
-
-1. Open the terminal dropdown in VS Code and switch the shell to
-   ``Command Prompt`` before running the activation command. This avoids the
-   default PowerShell execution-policy error that blocks ``Activate.ps1`` on
-   many fresh Windows setups.
-2. If your machine has multiple Python versions installed, use ``py -3.12`` or
-   another ``3.12+`` launcher entry for the commands below.
-
-.. code-block:: bat
-
-   py -3.12 -m venv .venv
-   .\.venv\Scripts\activate.bat
-
-4. Install The Package
-----------------------
-
-With the virtual environment active, run:
-
-.. code-block:: bash
-
    python -m pip install --upgrade pip
    python -m pip install design-research-agents
 
-Windows note:
-If ``python`` still points to an older interpreter after you reopen the
-terminal, go back to Step 3 and recreate ``.venv`` with ``py -3.12 -m venv
-.venv`` before retrying the install commands.
+On Windows PowerShell:
 
-If you want to connect to a specific model backend later, install only the
-extra you need. For example:
+.. code-block:: powershell
 
-.. code-block:: bash
+   py -3.12 -m venv .venv
+   .\.venv\Scripts\Activate.ps1
+   python -m pip install --upgrade pip
+   python -m pip install design-research-agents
 
-   python -m pip install "design-research-agents[openai]"
+Run ``Python: Select Interpreter`` from the command palette and choose the
+interpreter inside ``.venv``. If VS Code does not list it, enter the interpreter
+path manually:
 
-Use :doc:`dependencies_and_extras` for the full extras list.
+- macOS/Linux: ``.venv/bin/python``
+- Windows: ``.venv\Scripts\python.exe``
 
-5. Select The Python Interpreter
---------------------------------
-
-VS Code usually detects ``.venv`` automatically. If it does not:
-
-1. Open the Command Palette with ``Ctrl+Shift+P`` on Windows/Linux or
-   ``Cmd+Shift+P`` on macOS. You can also use ``View > Command Palette``.
-2. Run ``Python: Select Interpreter``.
-3. Choose the interpreter inside this workspace folder's ``.venv``.
-
-6. Create A First Script
-------------------------
-
-Create and save a file named ``hello_agents.py`` in your workspace folder.
-For example, use ``File > New File``, paste the code below, then save it as
-``hello_agents.py`` before trying to run it.
-
-Use this example:
+Create ``hello_agents.py`` in the workspace folder:
 
 .. code-block:: python
 
@@ -130,23 +75,22 @@ Use this example:
 
 
    agent = drag.DirectLLMCall(llm_client=HelloWorldLLMClient())
-   result = agent.run("Say hello to a new design research teammate.")
+   result = agent.run(
+       prompt="Say hello to a new design research teammate.",
+       request_id="example-vscode-hello-world-001",
+   )
    print(json.dumps(result.summary(), ensure_ascii=True, indent=2, sort_keys=True))
 
 This example uses only the published package API and does not require an API key
 or model server.
 
-7. Run The Script
------------------
+Run the file with VS Code's ``Run Python File`` action, or run:
 
-You can run the file in either of these ways:
+.. code-block:: bash
 
-- Click ``Run Python File`` in the editor.
-- Press ``F5`` and choose ``Python Debugger: Current File`` if VS Code asks.
+   python hello_agents.py
 
-A successful run prints a JSON summary in the integrated terminal.
-
-Expected output:
+A successful run prints a JSON summary in the integrated terminal:
 
 .. code-block:: json
 
@@ -154,33 +98,76 @@ Expected output:
      "error": null,
      "final_output": "Hello from design-research-agents.",
      "success": true,
-     "terminated_reason": null
+     "terminated_reason": null,
+     "trace": {
+       "request_id": "example-vscode-hello-world-001"
+     }
    }
 
-8. Troubleshooting
-------------------
+Source Checkout For Repository Examples
+---------------------------------------
 
-If the terminal says ``python`` or ``python3`` cannot be found:
+Use this path when you want the checked-in examples, docs, tests, and optional
+development tooling.
 
-- confirm Python finished installing
-- restart VS Code after installation
-- on Windows, reinstall Python and enable the PATH option
+.. code-block:: bash
 
-If imports are underlined after installation:
+   git clone https://github.com/cmudrc/design-research-agents.git
+   cd design-research-agents
+   python -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip setuptools wheel
+   python -m pip install -e ".[dev]"
 
-1. Run ``Python: Select Interpreter``.
-2. Pick the interpreter inside ``.venv``.
+Equivalent maintainer shortcut:
 
-If Windows PowerShell says scripts are disabled when you try to activate
-``.venv``:
+.. code-block:: bash
 
-1. Switch the VS Code terminal profile to ``Command Prompt`` and run
-   ``.\.venv\Scripts\activate.bat`` instead.
-2. If you want to stay in PowerShell, follow the
-   `Microsoft execution-policy guidance <https://go.microsoft.com/fwlink/?LinkID=135170>`_
-   before rerunning ``.\.venv\Scripts\Activate.ps1``.
+   make dev
 
-If you want a terminal-first workflow instead of VS Code:
+Run the deterministic VS Code onboarding example from the integrated terminal:
 
-- use :doc:`installation`
-- then continue with :doc:`quickstart`
+.. code-block:: bash
+
+   python examples/agents/vscode_hello_world.py
+   make examples-smoke
+
+First Development Checks
+------------------------
+
+Run the checks from VS Code's integrated terminal:
+
+.. code-block:: bash
+
+   make test
+   make qa
+   make docs-check
+
+``make qa`` runs linting, formatting checks, type checks, and tests. Run
+``make coverage`` before merge when changing tested behavior.
+
+Optional Model Backends
+-----------------------
+
+The base install supports deterministic local examples. Install model-client
+extras only when a workflow needs them. For example:
+
+.. code-block:: bash
+
+   python -m pip install "design-research-agents[openai]"
+
+Use :doc:`dependencies_and_extras` for the full extras list.
+
+Troubleshooting
+---------------
+
+- If VS Code imports fail but the terminal works, reselect the ``.venv``
+  interpreter and reload the window.
+- If ``make`` uses the wrong Python, activate ``.venv`` in the terminal or run
+  ``PYTHON=.venv/bin/python make test``.
+- If Windows activation is blocked, switch the terminal profile to Command
+  Prompt and run ``.\.venv\Scripts\activate.bat``.
+- If a model backend import is missing, install the matching backend extra
+  rather than broad optional dependencies.
+- Avoid committing generated runtime output under ``artifacts/``,
+  ``docs/_build/``, or local virtual environment directories.


### PR DESCRIPTION
## Summary
- make the VS Code guide use the same PyPI/source-checkout structure as the sibling packages
- keep the no-API-key hello-world script and make its expected trace output deterministic
- add the source checkout path for repository examples, dev checks, and optional model-client extras
- remove the README monthly release callout and AGENTS monthly release naming table
- keep future release planning issue/PR-scoped, with GitHub milestones treated as optional short-lived aids rather than release gates

Closes #109
Refs cmudrc/design-research#22

## Verification
- PyPI smoke-tested the documented starter snippets in a clean virtualenv
- `make docs-check`
- `make docs-build`